### PR TITLE
RPM Package support

### DIFF
--- a/rhel/dssim.spec
+++ b/rhel/dssim.spec
@@ -1,0 +1,43 @@
+Name:           dssim
+Version:        0.9
+Release:        1
+Summary:        This tool computes (dis)similarity between two (or more) PNG images
+
+Group:          Development/Tools
+License:        AGPLv3
+URL:            https://pornel.net/dssim
+Source0:        https://github.com/pornel/dssim/archive/%{version}.tar.gz
+BuildArch:      x86_64
+
+BuildRequires:	make
+BuildRequires:	libpng-devel
+
+%description
+This tool computes (dis)similarity between two (or more) PNG images using
+algorithm approximating human vision. Comparison is done using the SSIM
+algorithm (based on Rabah Mehdi's implementation) at multiple weighed
+resolutions. The value returned is 1/SSIM-1, where 0 means identical image,
+and >0 (unbounded) is amount of difference. Values are not directly comparable
+with other tools.
+
+%prep
+%setup
+
+%build
+make
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT%{_bindir}
+install -m 0755 dssim $RPM_BUILD_ROOT%{_bindir}/dssim
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/dssim
+
+%changelog
+* Mon Apr 13 2015 Harry Danes <harry@danes.eu> - 0.9-1
+- Initial release.


### PR DESCRIPTION
I would like to add the `SPEC` definition which can be used to generate a RPM package. This file is compatible with version 0.9. A small modification might be necessary to make it compatible with the future version which contains the Debian packaging information.

### rpmlint
The package is verified with rpmlint

[user@host]# rpmlint dssim-0.9-1.x86_64.rpm
dssim.x86_64: I: enchant-dictionary-not-found en_US
dssim.x86_64: W: no-documentation
1 packages and 0 specfiles checked; 0 errors, 1 warnings.   


### test environments
- Centos 6.x 