### PR TITLE
Add jpeg support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ CFLAGSOPT ?= -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-fr
 CFLAGS ?= -Wall -I. $(CFLAGSOPT)
 CFLAGS += -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags` $(CFLAGSADD)
 
+
+
+ifdef USE_LIBJPEG
+LDFLAGS += -ljpeg
+CFLAGS += -DUSE_LIBJPEG
+endif
+ 
 LDFLAGS += `pkg-config libpng --libs || pkg-config libpng16 --libs` -lm -lz $(LDFLAGSADD)
 
 ifdef USE_COCOA

--- a/src/main.c
+++ b/src/main.c
@@ -79,8 +79,7 @@ static int read_image_jpeg(const char *filename, png24_image *image)
     row_stride=width*bpp;
 
     // allocate buffer size (always use RGBA)
-    unsigned char* buffer = malloc(width*height*bpp);
-    memset(buffer,0x0,width*height*bpp);
+    unsigned char* buffer = calloc(width*height*bpp,1);
 
     while(cinfo.output_scanline < height)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,6 @@ static int read_image_jpeg(const char *filename, png24_image *image)
     unsigned int width,height,row_stride;
     unsigned int bpp;
     unsigned int x,y,i;
-
     struct jpeg_decompress_struct cinfo;
     struct jpeg_error_mgr jerr;
     cinfo.err = jpeg_std_error(&jerr);
@@ -80,7 +79,7 @@ static int read_image_jpeg(const char *filename, png24_image *image)
     row_stride=width*bpp;
 
     // allocate buffer size (always use RGBA)
-    unsigned char* buffer = (unsigned char*)malloc(width*height*bpp);
+    unsigned char* buffer = malloc(width*height*bpp);
     memset(buffer,0x0,width*height*bpp);
 
     while(cinfo.output_scanline < height)
@@ -91,9 +90,8 @@ static int read_image_jpeg(const char *filename, png24_image *image)
     }
 
     //convert to RGBA
-    image->rgba_data = (unsigned char*)malloc(width*height*4);
-    memset(image->rgba_data,0x0,width*height*4);
-    image->row_pointers = (unsigned char**) malloc(height*sizeof(unsigned char*));
+    image->rgba_data = calloc(width*height*4,1);
+    image->row_pointers = calloc(height,sizeof(unsigned char*));
 
     for(y=0;y<height;y++)
     {
@@ -120,19 +118,19 @@ static int read_image_jpeg(const char *filename, png24_image *image)
 static int read_image(const char *filename, png24_image *image)
 {
     int retval=1;
+    unsigned char *header;
     // read first 4 byte to determine filetype by magical number
     FILE *fp = fopen(filename,"rb");
     if(!fp)
     {
         return 1;
     }
-    unsigned char *header = (unsigned char*)malloc(4*sizeof(unsigned char));
-    memset(header,0x0,4*sizeof(unsigned char));
+    header = calloc(4,1);
     if(!header)
     {
         return 1;
     }
-    fread(header,sizeof(unsigned char),4,fp);
+    fread(header,1,4,fp);
     fclose(fp);
 
     // the png number is not really precise but I guess the situation where this would falsely pass is almost equal to 0

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,6 @@ static int read_image_jpeg(const char *filename, png24_image *image)
     retval=jpeg_read_header(&cinfo,TRUE);
     if(retval != 1)
     {
-        printf("invalid jpeg header\n");
         return 1;
     }
     jpeg_start_decompress(&cinfo);
@@ -143,7 +142,6 @@ static int read_image(const char *filename, png24_image *image)
     }
 #ifdef USE_LIBJPEG
     else
-    if(header[0]==0xff && header[1]==0xd8 && header[2]==0xff && (header[3]==0xdb || header[3]==0xe0 || header[3]==0xe1))
     {
         retval=read_image_jpeg(filename,image);
     }


### PR DESCRIPTION
I had the need to add jpeg support. The solution is far from elegant but gets the job done. If someone wants to write a more proper version where gamma is calculated I would be grateful.

I added USE_LIBJPEG flag to Makefile and moved some code so that the loader of the image populates the png24_image struct with either jpeg or png data depending on file extension.
