### PR TITLE
Exposing image comparison in shared object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,13 @@ OBJS = $(LIBOBJS) $(SRC)rwpng.o $(SRC)main.o
 COCOASRC =
 BIN = $(DESTDIR)$(PREFIX)dssim
 STATICLIB = $(DESTDIR)$(PREFIX)libdssim.a
+SHARED_LIB_FILE = libdssim.so
+SHARED_LIB = $(DESTDIR)$(PREFIX)$(SHARED_LIB_FILE)
 
-CFLAGSOPT ?= -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only
+INSTALL_LIB_DIR = /usr/lib/
+INSTALL_INCLUDE_DIR = /usr/include/dssim/
+
+CFLAGSOPT ?= -DNDEBUG -O3 -fstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -ffinite-math-only -fpic
 CFLAGS ?= -Wall -I. $(CFLAGSOPT)
 CFLAGS += -std=c99 `pkg-config libpng --cflags || pkg-config libpng16 --cflags` $(CFLAGSADD)
 
@@ -29,6 +34,18 @@ endif
 
 all: $(BIN)
 
+shared: $(SHARED_LIB)
+
+install: shared
+	-cp $(SHARED_LIB) $(INSTALL_LIB_DIR)
+	-mkdir -p $(INSTALL_INCLUDE_DIR)
+	-cp $(SRC)dssim_helpers.h $(INSTALL_INCLUDE_DIR)
+	ldconfig
+
+uninstall:
+	-ls $(INSTALL_LIB_DIR)$(SHARED_LIB_FILE) && rm $(INSTALL_LIB_DIR)$(SHARED_LIB_FILE)
+	-ls $(INSTALL_INCLUDE_DIR) && rm -rf $(INSTALL_INCLUDE_DIR)
+
 $(SRC)%.o: $(SRC)%.c $(SRC)%.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
@@ -39,7 +56,10 @@ $(BIN): $(OBJS) $(COCOASRC)
 $(STATICLIB): $(LIBOBJS)
 	$(AR) $(ARFLAGS) $@ $^
 
+$(SHARED_LIB): $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $^
+
 clean:
-	-rm -f $(BIN) $(OBJS)
+	-rm -f $(BIN) $(OBJS) $(SHARED_LIB)
 
 .PHONY: all clean

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,6 @@
-project ('dssim', 'C')
+project ('dssim', 'C',
+  version : '1.3.2.1',
+  default_options : [ 'warning_level=1'])
 
 dssim_lib_sources = ['src/dssim.c']
 

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,9 @@ libdssim = shared_library('dssim-lib',
 			  c_args: c_args,
 			  install:true)
 
+dssim_dep = declare_dependency(link_with : libdssim,
+  include_directories : include_directories('src/'))
+
 h = install_headers ('src/dssim.h')
 
 pkgconfig_gen(libraries : libdssim,

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project ('dssim', 'C',
   version : '1.3.2.1',
+  meson_version : '>= 0.35.0',
   default_options : [ 'warning_level=1'])
 
 dssim_lib_sources = ['src/dssim.c']
@@ -15,8 +16,9 @@ c_args = ['-DNDEBUG',
       '-Wall',
       '-std=c99']
 
-mathlib = find_library('m', required : true)
-zlib = find_library('z', required : true)
+cc = meson.get_compiler('c')
+mathlib = cc.find_library('m')
+zlib = cc.find_library('z')
 
 libdssim = shared_library('dssim-lib',
               dssim_lib_sources,
@@ -30,16 +32,15 @@ dssim_dep = declare_dependency(link_with : libdssim,
 
 h = install_headers ('src/dssim.h')
 
-pkgconfig_gen(libraries : libdssim,
-          subdirs : '.',
-          name : 'libdssim',
-          filebase : 'dssim',
-          version : '1.1',
-          description : 'A structural similarity library.')
+pkg = import('pkgconfig')
+pkg.generate(libraries : libdssim,
+             subdirs : '.',
+             name : 'libdssim',
+             filebase : 'dssim',
+             version : meson.project_version(),
+             description : 'A structural similarity library.')
 
 png_dep = dependency('libpng')
-
-
 executable = executable ('dssim',
              dssim_sources,
              install: true,

--- a/meson.build
+++ b/meson.build
@@ -3,29 +3,27 @@ project ('dssim', 'C',
   default_options : [ 'warning_level=1'])
 
 dssim_lib_sources = ['src/dssim.c']
-
 dssim_sources = ['src/main.c',
-		 'src/rwpng.c']
+         'src/rwpng.c']
 
 c_args = ['-DNDEBUG',
-	  '-O3',
-	  '-fstrict-aliasing',
-	  '-ffast-math',
-	  '-funroll-loops',
-	  '-fomit-frame-pointer',
-	  '-ffinite-math-only',
-	  '-Wall',
-	  '-std=c99']
+      '-fstrict-aliasing',
+      '-ffast-math',
+      '-funroll-loops',
+      '-fomit-frame-pointer',
+      '-ffinite-math-only',
+      '-Wall',
+      '-std=c99']
 
 mathlib = find_library('m', required : true)
 zlib = find_library('z', required : true)
 
 libdssim = shared_library('dssim-lib',
-			  dssim_lib_sources,
-			  version: '1.1',
-			  dependencies: [mathlib, zlib],
-			  c_args: c_args,
-			  install:true)
+              dssim_lib_sources,
+              version: '1.1',
+              dependencies: [mathlib, zlib],
+              c_args: c_args,
+              install:true)
 
 dssim_dep = declare_dependency(link_with : libdssim,
   include_directories : include_directories('src/'))
@@ -33,18 +31,18 @@ dssim_dep = declare_dependency(link_with : libdssim,
 h = install_headers ('src/dssim.h')
 
 pkgconfig_gen(libraries : libdssim,
-	      subdirs : '.',
-	      name : 'libdssim',
-	      filebase : 'dssim',
-	      version : '1.1',
-	      description : 'A structural similarity library.')
+          subdirs : '.',
+          name : 'libdssim',
+          filebase : 'dssim',
+          version : '1.1',
+          description : 'A structural similarity library.')
 
 png_dep = dependency('libpng')
 
 
 executable = executable ('dssim',
-			 dssim_sources,
-			 install: true,
-			 c_args: c_args,
-			 dependencies: [png_dep],
-			 link_with: [libdssim])
+             dssim_sources,
+             install: true,
+             c_args: c_args,
+             dependencies: [png_dep],
+             link_with: [libdssim])

--- a/src/dssim_helpers.h
+++ b/src/dssim_helpers.h
@@ -1,0 +1,28 @@
+/*
+ * © 2011-2015 Kornel Lesiński. All rights reserved.
+ *
+ * This file is part of DSSIM.
+ *
+ * DSSIM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * DSSIM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the license along with DSSIM.
+ * If not, see <http://www.gnu.org/licenses/agpl.txt>.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int process_images(int argc, char *const argv[], char *map_output_file);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,6 @@
 extern char *optarg;
 extern int optind, opterr;
 
-
 #ifdef USE_LIBJPEG
 #include <jpeglib.h>
 static int read_image_jpeg(FILE *file, png24_image *image)
@@ -211,6 +210,89 @@ double get_gamma(const png24_image *image) {
     return 0.45455;
 }
 
+int process_images(int num_images,
+			char *const image_list[],
+			char*map_output_file,
+			double* results)
+{
+    const char *file1 = image_list[0];
+    png24_image image1 = {};
+    int retval = read_image(file1, &image1);
+
+    if (retval) {
+        fprintf(stderr, "Can't read %s (%d)\n", file1, retval);
+        return retval;
+    }
+
+    dssim_attr *attr = dssim_create_attr();
+
+    dssim_image *original = dssim_create_image(attr, image1.row_pointers, DSSIM_RGBA, image1.width, image1.height, get_gamma(&image1));
+    free(image1.row_pointers);
+    free(image1.rgba_data);
+
+    // start at 1, skipping the first image in the list
+    for (int i = 1; i < num_images; i++) {
+        const char *file2 = image_list[i];
+
+        png24_image image2 = {};
+        retval = read_image(file2, &image2);
+        if (retval) {
+            fprintf(stderr, "Can't read %s (%d)\n", file2, retval);
+            break;
+        }
+
+        if (image1.width != image2.width || image1.height != image2.height) {
+            fprintf(stderr, "Image %s has different size than %s\n", file2, file1);
+            retval = 4;
+            break;
+        }
+
+        dssim_image *modified = dssim_create_image(attr, image2.row_pointers, DSSIM_RGBA, image2.width, image2.height, get_gamma(&image2));
+        free(image2.row_pointers);
+        free(image2.rgba_data);
+
+        if (!modified) {
+            fprintf(stderr, "Unable to process image %s\n", file2);
+            retval = 4;
+            break;
+        }
+
+        if (map_output_file) {
+            dssim_set_save_ssim_maps(attr, 1, 1);
+        }
+
+        results[i] = dssim_compare(attr, original, modified);
+        dssim_dealloc_image(modified);
+
+        if (map_output_file) {
+            dssim_ssim_map map_meta = dssim_pop_ssim_map(attr, 0, 0);
+            dssim_px_t *map = map_meta.data;
+            dssim_rgba *out = (dssim_rgba*)map;
+            for(int i=0; i < map_meta.width*map_meta.height; i++) {
+                const dssim_px_t max = 1.0 - map[i];
+                const dssim_px_t maxsq = max * max;
+                out[i] = (dssim_rgba) {
+                    .r = to_byte(max * 3.0),
+                    .g = to_byte(maxsq * 6.0),
+                    .b = to_byte(max / ((1.0 - map_meta.dssim) * 4.0)),
+                    .a = 255,
+                };
+            }
+            if (write_image(map_output_file, out, map_meta.width, map_meta.height)) {
+                fprintf(stderr, "Can't write %s\n", map_output_file);
+                free(map);
+                return 1;
+            }
+            free(map);
+        }
+    }
+
+    dssim_dealloc_image(original);
+    dssim_dealloc_attr(attr);
+
+    return retval;
+}
+
 int main(int argc, char *const argv[])
 {
     char *map_output_file = NULL;
@@ -241,83 +323,29 @@ int main(int argc, char *const argv[])
         return 1;
     }
 
-    const char *file1 = argv[optind];
-    png24_image image1 = {};
-    int retval = read_image(file1, &image1);
+    int num_images = argc-1;
+    char* image_list[num_images];
+    double results[num_images];
+    int retval;
 
-    if (retval) {
-        fprintf(stderr, "Can't read %s (%d)\n", file1, retval);
-        return retval;
+    // Build up a list of images so we don't have to pass along argc/argv
+    // Also, initialize results
+    results[0] = 0.0;
+    for(int image_index=1; image_index < argc; image_index++) {
+    	image_list[image_index-1] = argv[image_index];
+
+	results[image_index] = 0.0;
     }
 
-    dssim_attr *attr = dssim_create_attr();
-
-    dssim_image *original = dssim_create_image(attr, image1.row_pointers, DSSIM_RGBA, image1.width, image1.height, get_gamma(&image1));
-    free(image1.row_pointers);
-    free(image1.rgba_data);
-
-
-    for (int arg = optind+1; arg < argc; arg++) {
-        const char *file2 = argv[arg];
-
-        png24_image image2 = {};
-        retval = read_image(file2, &image2);
-        if (retval) {
-            fprintf(stderr, "Can't read %s (%d)\n", file2, retval);
-            break;
-        }
-
-        if (image1.width != image2.width || image1.height != image2.height) {
-            fprintf(stderr, "Image %s has different size than %s\n", file2, file1);
-            retval = 4;
-            break;
-        }
-
-        dssim_image *modified = dssim_create_image(attr, image2.row_pointers, DSSIM_RGBA, image2.width, image2.height, get_gamma(&image2));
-        free(image2.row_pointers);
-        free(image2.rgba_data);
-
-        if (!modified) {
-            fprintf(stderr, "Unable to process image %s\n", file2);
-            retval = 4;
-            break;
-        }
-
-        if (map_output_file) {
-            dssim_set_save_ssim_maps(attr, 1, 1);
-        }
-
-        double dssim = dssim_compare(attr, original, modified);
-        dssim_dealloc_image(modified);
-
-        printf("%.8f\t%s\n", dssim, file2);
-
-
-        if (map_output_file) {
-            dssim_ssim_map map_meta = dssim_pop_ssim_map(attr, 0, 0);
-            dssim_px_t *map = map_meta.data;
-            dssim_rgba *out = (dssim_rgba*)map;
-            for(int i=0; i < map_meta.width*map_meta.height; i++) {
-                const dssim_px_t max = 1.0 - map[i];
-                const dssim_px_t maxsq = max * max;
-                out[i] = (dssim_rgba) {
-                    .r = to_byte(max * 3.0),
-                    .g = to_byte(maxsq * 6.0),
-                    .b = to_byte(max / ((1.0 - map_meta.dssim) * 4.0)),
-                    .a = 255,
-                };
-            }
-            if (write_image(map_output_file, out, map_meta.width, map_meta.height)) {
-                fprintf(stderr, "Can't write %s\n", map_output_file);
-                free(map);
-                return 1;
-            }
-            free(map);
+    if( (retval = process_images(num_images,
+    				image_list,
+				map_output_file,
+                                results) ) == 0) {
+        // Skipping first image here as well, so start at index 1
+        for (int results_index=1; results_index < num_images; results_index++) {
+            printf("%.8f\t%s\n", results[results_index], image_list[results_index]);
         }
     }
-
-    dssim_dealloc_image(original);
-    dssim_dealloc_attr(attr);
 
     return retval;
 }


### PR DESCRIPTION
This pull request might be a bit more "controversial", so expecting some pushback.

Basically, I would love to expose dssim as a PHP extension (I've already gotten the basics of that worked out elsewhere working). This gets me there by changing some of the core assumptions of dssim. The makefile changes allow for "sudo make install" which will drop the .so file by default in /usr/lib and the header in /usr/include/dssim/. Then I reworked the main.c changes so it splits up the cli arg parts from the central image comparison parts.

Some things in particular I'm not crazy about that I'd love more feedback on:
1) The Makefile - could totally see this not being ideal (I'm not a pro at making Makefiles) so if you have more paradigmatic approaches, I'm game. Also could've included (or even separating out) the dssim binary and dropping that elsewhere (as mentioned in #28 )
2) Naming - "process_images" isn't a great method name.
3) header file naming - "dssim_helpers.h" also not great, kinda hate calling things "helpers".
4) Handling of results - Since I want to expose the core, I wanted to return results rather than print them as they go. This means if there's a nonzero return value from process_images, it's not going to print any, which makes this functionally different than before. Can rework.

This is turning into an essay :) Would love to hear feedback on this. Thanks again for the fast responses!